### PR TITLE
Feature/api change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchover-js-core",
-  "version": "0.6.9",
+  "version": "1.0.0",
   "description": "Switchover core library",
   "main": "./dist/index.js",
   "module": "./esm/index.js",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -58,8 +58,8 @@ export class Client {
 
     /**
      * Initially Fetches all toggles from server and then fetch from cache. Callback will be triggerd when fetching is done.
-     * 
-     * @param cb 
+     *
+     * @param cb
      */
     fetch(cb: () => void) {
         if (!this.cache.getValue(this.sdkKey)) {
@@ -129,7 +129,7 @@ export class Client {
      * Manually refreshes toggles. If toggles were updated, callback will hold the changed toggle keys.
      * If nothing has changed, keys are null.
      *
-     * @param cb 
+     * @param cb
      */
     refresh(cb: (keys: string[]) => void) {
         this.doRefresh(cb);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -44,20 +44,14 @@ export class Client {
         
         this.initOptionListeners();
 
-        /*
-        this.fetcher.fetchAll(this.sdkKey).then( apiResponse => {
-            this.logger.debug('Fetch all config on client initialization');
-
-            //fill cache
-            this.cache.setValue(sdkKey, apiResponse);
-            //emit loaded event
-            this.emitter.emit('loaded');
-
-            this.logger.debug('Loaded config');
-        })*/
-
         this.initPolling();
     }
+
+    isCacheFilled() {
+        const response = this.cache.getValue(this.sdkKey);
+        return response != null;
+    }
+
 
     /**
      * Fetches all toggles from server or cache. Callback will be triggerd when fetching is done.
@@ -85,9 +79,6 @@ export class Client {
 
 
     private initOptionListeners() {
-        if (this.options.onInit) {
-            this.onInit(this.options.onInit);
-        }
         if (this.options.onUpdate) {
             this.onUpdate(this.options.onUpdate);
         }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -183,8 +183,8 @@ export class Client {
         if (this.options.autoRefresh) {
             this.logger.debug('Init AutoRefresh...')
             let interval = this.options.refreshInterval;
-            if (!interval) {
-                this.logger.debug('AutoRefresh activated, no interval set, using default');
+            if (!interval || interval < 10) {
+                this.logger.debug('AutoRefresh activated, no interval set or is below 10sec, using default');
                 interval = 60;
             }
             this.logger.debug('Init polling with interval=' + interval);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -173,38 +173,6 @@ export class Client {
         });
     }
 
-    /**
-     * Forces a refresh. This eventually can trigger an update event if toggles changed
-     * or never been loaded to the cache.
-     * 
-     * @deprecated
-     */
-    forceRefresh() {
-        const { lastModified, payload } = this.cache.getValue(this.sdkKey) || {
-            lastModified: null,
-            payload: null
-        };
-        const oldCacheResult = payload;
-
-        this.fetcher.fetchAll(this.sdkKey, lastModified).then( result => {
-
-            //check also the lastModified value
-            if (result && result.lastModified !== lastModified) {
-
-                //get changed toggles
-                let changed = this.getChangedKeys(result, oldCacheResult);
-
-                //fill cache
-                this.cache.setValue(this.sdkKey, result);
-
-                
-            }
-        }).catch(err => {
-            this.logger.error(err);
-            this.logger.error(`Failed to load. Server sent ${err.status} ${err.text}`);
-        });
-    }
-
     private getChangedKeys(result: ApiResponse, oldCacheResult: any) {
         if (oldCacheResult) {
             return result.payload.filter( resultToggle => {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -77,6 +77,16 @@ export class Client {
     }
 
 
+    /**
+     * Fetch as promise
+     */
+    fetchPromise() : Promise<void> {
+        return new Promise( (resolve, _) => {
+            this.fetch( () => resolve() );
+        })
+    }
+
+
 
     private initOptionListeners() {
         if (this.options.onUpdate) {

--- a/src/Evaluator.ts
+++ b/src/Evaluator.ts
@@ -14,7 +14,7 @@ export class Evaluator {
 
     private logger: Logger = Logger.getLogger();
 
-    public evaluate(config: any, name: string, context: any, defaultValue: boolean) :boolean {
+    public evaluate(config: any, name: string, context: any, defaultValue: any){
         this.logger.debug('Evalutate config for toggle ' + name);
 
         if (!config) {
@@ -42,7 +42,7 @@ export class Evaluator {
         return defaultValue;
     }
 
-    private evaluateOnActive(toggle, context, defaultValue) {
+    private evaluateOnActive(toggle, context, defaultValue: any) {
         if (this.hasConditions(toggle)) {
             return this.evaluateWithConditions(toggle, context, defaultValue);
         }
@@ -53,7 +53,7 @@ export class Evaluator {
         return toggle.conditions &&  toggle.conditions.length > 0;
     }
 
-    private evaluateWithConditions(toggle, context, defaultValue) : boolean {
+    private evaluateWithConditions(toggle, context, defaultValue) {
         this.logger.debug('Evaluate toggle with conditions');
     
         if (!context && this.hasConditions(toggle) ) {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,6 +1,6 @@
 export interface Options {
     autoRefresh?: boolean;
     refreshInterval?: number;
-    onInit?: () => void;
+    /** @deprecated */onInit?: () => void;
     onUpdate?: (key: string[]) => void;
 }

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,6 +1,5 @@
 export interface Options {
     autoRefresh?: boolean;
     refreshInterval?: number;
-    /** @deprecated */onInit?: () => void;
     onUpdate?: (key: string[]) => void;
 }

--- a/test/Client.spec.ts
+++ b/test/Client.spec.ts
@@ -85,7 +85,7 @@ test('Test isCachedFilled', done => {
         new MemoryCache(),
         mockFetcher,
         sdkKey,
-        { autoRefresh: false }, 
+        { autoRefresh: false },
         'info');
 
     expect(client.isCacheFilled()).toBeFalsy();
@@ -126,10 +126,10 @@ test('Test onUpdate with auto-refresh interval 2s', done => {
         new MemoryCache(),
         mockFetcher,
         sdkKey,
-        { 
+        {
             refreshInterval: 2,
             autoRefresh: true,
-            onUpdate: onUpdateCallback 
+            onUpdate: onUpdateCallback
         },
         'info');
 })

--- a/test/Client.spec.ts
+++ b/test/Client.spec.ts
@@ -56,6 +56,24 @@ test('Test fetch', done => {
       
 });
 
+test('Test fetchPromise', async () => {
+    const sdkKey = 'some_key'
+
+    mockFetcher.fetchAll.mockImplementation( () => Promise.resolve(response1));
+
+    const cache = new MemoryCache();
+    const client = new Client(
+            new Evaluator(),
+            new EventEmitter(),
+            cache, mockFetcher,
+            sdkKey, { autoRefresh: false }, 'info');
+
+    await client.fetchPromise();
+
+    expect(mockFetcher.fetchAll).toBeCalledTimes(1);
+    expect(cache.getValue(sdkKey).lastModified).toEqual(response1.lastModified);
+})
+
 test('Test isCachedFilled', done => {
     const sdkKey = 'some_key'
 

--- a/test/Evaluator.spec.ts
+++ b/test/Evaluator.spec.ts
@@ -31,7 +31,7 @@ test('test evaluation active without conditions', () => {
 
     const testConfig = [
         Object.assign(config[0], { conditions: []})
-    ] 
+    ]
 
     expect(evaluator.evaluate(testConfig, 'toggle-001', context, false))
         .toBeTruthy();
@@ -46,7 +46,7 @@ test('test evaluation always inactive', () => {
 
     const testConfig = [
         Object.assign(config[0], { status: 4})
-    ] 
+    ]
 
     expect(evaluator.evaluate(testConfig, 'toggle-001', context, true))
         .toBeTruthy();
@@ -65,7 +65,7 @@ test('test evaluation strategy all conditions true', () => {
 
     const testConfig = [
         Object.assign(config[0], { status: 1, strategy: 3 }) // STRAGEGY_ALL
-    ] 
+    ]
 
     expect(evaluator.evaluate(testConfig, 'toggle-001', context, true)).toBeTruthy();
 })

--- a/test/Evaluator.spec.ts
+++ b/test/Evaluator.spec.ts
@@ -142,3 +142,48 @@ test('test evaluation strategy majority of conditions are true', () => {
 
     expect(evaluator.evaluate(majorityConfig, 'toggle-001', context, true)).toBeTruthy();
 })
+
+test('Evaluation with int value', () => {
+    const config = [{
+        name: "toggle-001",
+        status: 1,
+        type: 2,
+        value: 4,
+        strategy: 3
+    }];
+
+    const evaluator = new Evaluator();
+    const value = evaluator.evaluate(config, config[0].name, {}, 3);
+    expect(value).toBe(config[0].value);
+});
+
+test('Evaluation with double/float value, recieving default value', () => {
+    const config = [{
+        name: "toggle-001",
+        status: 3, /* not active */
+        type: 3,
+        value: 2.3,
+        strategy: 3
+    }];
+
+    const evaluator = new Evaluator();
+    const value = evaluator.evaluate(config, config[0].name, {}, 5.1);
+    expect(value).toBe(5.1);
+});
+
+test('Evaluation with json value', () => {
+    const config = [{
+        name: "toggle-001",
+        status: 1, /* active */
+        type: 4,
+        value: {
+            host: "service01.tld"
+        },
+        strategy: 3
+    }];
+
+    const evaluator = new Evaluator();
+    const value = evaluator.evaluate(config, config[0].name, {}, { host: 'dummy'});
+    expect(value.host).toBe("service01.tld");
+});
+


### PR DESCRIPTION
Breaking Changes:
- `forceRefresh` is removed in favor for `refresh(cb: (keys: string[] => void)` and `refreshAsync()`
- `onInit` callback method is removed in favor for `fetch(cb: () => void)` and `fetchAsync` which fetches toggles from server/cache. Can be called any time. 

Major Changes:
- `toggleValue` can now return boolean, integer, double or json values. Default values can also be set to this data types.

Minor Changes:
- Add method `isCachedFilled` as indicator if toggle cached is already filled


